### PR TITLE
Autocomplete uses current working directory instead of root for relative paths

### DIFF
--- a/src-tauri/src/commands/shell.rs
+++ b/src-tauri/src/commands/shell.rs
@@ -150,7 +150,13 @@ fi
 #[tauri::command]
 pub fn get_current_dir() -> Result<String, String> {
     std::env::current_dir()
-        .map(|path| path.to_string_lossy().into_owned())
+        .map(|path| {
+            let mut normalized = path.to_string_lossy().replace("\\", "/");
+            if let Some(index) = normalized.find(':') {
+                normalized = format!(".{}", &normalized[index + 1..]);
+            }
+            normalized
+        })
         .map_err(|e| format!("Failed to get current directory: {}", e))
 }
 

--- a/src-tauri/src/commands/shell.rs
+++ b/src-tauri/src/commands/shell.rs
@@ -161,6 +161,16 @@ pub fn get_current_dir() -> Result<String, String> {
 }
 
 #[tauri::command]
+pub fn get_home_dir() -> Result<String, String> {
+    if let Some(home) = dirs::home_dir() {
+        Ok(home.to_string_lossy().into_owned())
+    } else {
+        Err("Failed to get home directory".to_string())
+    }
+}
+
+
+#[tauri::command]
 pub async fn list_directory_contents(path: Option<String>) -> Result<Vec<String>, String> {
     let dir_path = match path {
         Some(p) if !p.is_empty() => p,

--- a/src/components/Terminal/TerminalInput.tsx
+++ b/src/components/Terminal/TerminalInput.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect, useState } from 'react';
 import useCommandHistory from '../../hooks/useCommandHistory';
-import { getAutocompleteSuggestions } from '../../utils/autocomplete';
+import { getAutocompleteSuggestions, refreshCurrentDir } from '../../utils/autocomplete';
 
 interface TerminalInputProps {
     input: string;
@@ -155,20 +155,18 @@ const TerminalInput: React.FC<TerminalInputProps> = ({
         }
     };
 
-    const handleSubmitWrapper = (e: React.FormEvent) => {
+    const handleSubmitWrapper = async (e: React.FormEvent) => {
         e.preventDefault();
-        if (!input.trim()) return;
-
-        if (input.trim()) {
-            addToHistory(input.trim());
-        }
-
+        const trimmedInput = input.trim();
+        if (!trimmedInput) return;
+        if (trimmedInput) addToHistory(input.trim());  
         setSuggestions([]);
         setCurrentSuggestionIndex(0);
         setShowCompletionHelp(false);
         setTabPressCount(0);
 
         onSubmit(e);
+        if (trimmedInput.startsWith('cd ')) await refreshCurrentDir();//refresh cached dir on `cd`
     };
 
     return (

--- a/src/utils/autocomplete.ts
+++ b/src/utils/autocomplete.ts
@@ -116,7 +116,7 @@ export async function getAutocompleteSuggestions(input: string): Promise<Autocom
     if (!input.trim()) {
         return { suggestions: [] };
     }
-
+    const currentDir = await getHomeDirectory();
     const words = input.split(' ');
     const lastWord = words[words.length - 1];
     const isFirstWord = words.length === 1;
@@ -124,7 +124,8 @@ export async function getAutocompleteSuggestions(input: string): Promise<Autocom
 
     // Special case: command with space at the end - suggest files in current directory
     if (input.endsWith(' ')) {
-        const files = await invoke<string[]>('list_directory_contents', { path: '.' });
+        const files = await invoke<string[]>('list_directory_contents', { path: currentDir });
+        console.log(currentDir)
         return { suggestions: files };
     }
 
@@ -158,6 +159,9 @@ export async function getAutocompleteSuggestions(input: string): Promise<Autocom
 
     try {
         let dirPath = dirToSearch;
+        if (dirPath === '.') {
+            dirPath = await getHomeDirectory();
+        }
         if (dirPath.startsWith('~')) {
             dirPath = await expandPath(dirPath);
         }


### PR DESCRIPTION
This PR fixes an issue where the autocomplete feature was suggesting files and directories from the root directory when the user typed commands like cd, touch, etc. and pressed Tab. Previously, the `getAutocompleteSuggestions` function defaulted to . (root) when no path was provided, ignoring the actual current working directory.

Fixed issue #17 
<img width="1011" height="778" alt="image" src="https://github.com/user-attachments/assets/68580c40-ef84-4429-be9f-93028f69affc" />
